### PR TITLE
Update installation.html to celluloid

### DIFF
--- a/installation.html
+++ b/installation.html
@@ -83,7 +83,7 @@
 				flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 			</code>
 			<code>
-				flatpak install flathub io.github.GnomeMpv
+				flatpak install flathub io.github.celluloid_player.Celluloid
 			</code>
 			<p>Development versions are also packaged:</p>
 			<code>


### PR DESCRIPTION
From gnome-mpv to io.github.celluloid_player.Celluloid, there is maybe some other place that needs to be changed I just wanted to install it and found this error. Thanks for the good work